### PR TITLE
Refactor `_split_pascal_case` function

### DIFF
--- a/crescent/ext/kebab/__init__.py
+++ b/crescent/ext/kebab/__init__.py
@@ -13,19 +13,14 @@ if typing.TYPE_CHECKING:
 
 
 def _split_pascal_case(s: str) -> list[str]:
-    word_breaks: list[int] = []
+    words = []
+    last = 0
+    for c, char in enumerate(s):
+        if c and char.isupper():
+            words.append(s[last:c])
+            last = c
 
-    for index, (maybe_lower, maybe_upper) in enumerate(pairwise(s)):
-        if maybe_lower.islower() and maybe_upper.isupper():
-            word_breaks.append(index + 1)
-
-    if not word_breaks:
-        return [s]
-
-    words: list[str] = []
-    for start, end in pairwise([0, *word_breaks, len(s)]):
-        words.append(s[start:end])
-
+    words.append(s[last:])
     return words
 
 


### PR DESCRIPTION
- Increase `_split_pascal_case` speed by using a simpler algorithm.

## Tests
Speed result for a string with 1 million words

### Old 
```py
def _split_pascal_case(s: str) -> list[str]:
    word_breaks: list[int] = []

    for index, (maybe_lower, maybe_upper) in enumerate(pairwise(s)):
        if maybe_lower.islower() and maybe_upper.isupper():
            word_breaks.append(index + 1)

    if not word_breaks:
        return [s]

    words: list[str] = []
    for start, end in pairwise([0, *word_breaks, len(s)]):
        words.append(s[start:end])

    return words
```
```
0.654s
```

### New
```py
def _split_pascal_case(s: str) -> list[str]:
    words = []
    last = 0
    for c, char in enumerate(s):
        if c and char.isupper():
            words.append(s[last:c])
            last = c

    words.append(s[last:])
    return words
```
```
0.416s
```

### Variant

A even simpler algorithm that is not too far beyond the fastest version
```py
def _split_pascal_case(s: str) -> list[str]:
    words = []
    word = ''
    for c, char in enumerate(s):
        if c and char.isupper():
            words.append(word)
            word = char
        else:
            word += char
    words.append(word)
    return words
```

```
0.471s
```